### PR TITLE
리팩토링 : 스케줄러, CPU 로직 변경

### DIFF
--- a/CPU.py
+++ b/CPU.py
@@ -2,20 +2,23 @@ class CPU:
     def __init__(self, cpu_id):
         self.cpu_id = cpu_id
         self.process = None
-        self.end_time = -1
+        self.work_time = 0
 
     def is_idle(self):
         return self.process is None
 
     def set_idle(self):
         self.process = None
+        self.work_time = 0
 
-    def set_process(self, process, cur_time, end_time):
+
+    def set_process(self, process):
         self.process = process
-        self.end_time = end_time
-        self.process.remain_BT -= end_time - cur_time
 
-    def is_finished(self, cur_time):
-        if cur_time == self.end_time:
-            return True
+    def is_finished(self, quantum = -1):
+        if not self.is_idle():
+            if self.process.remain_BT == 0:
+                return True
+            if quantum != -1 and self.work_time == quantum:
+                return True
         return False

--- a/FCFS.py
+++ b/FCFS.py
@@ -18,11 +18,11 @@ class FCFS(Scheduler):
                 elif process.AT > cur_time:
                     AT_idx = process_idx
                     break
-
+            super().work()
             # cpu들을 돌면서
             for cpu in self.cpus:
                 # cpu의 일이 끝났으면
-                if cpu.is_finished(cur_time):
+                if cpu.is_finished():
                     # 프로세스가 완전히 끝나면 현재시간을 기준으로 각 time을 계산
                     # 끝난 프로세스의 개수 1 증가
                     print("processe finished - cur_time:", cur_time, " p_id :", cpu.process.process_id)
@@ -35,7 +35,6 @@ class FCFS(Scheduler):
                 if cpu.is_idle():
                     # 대기열에 프로세스가 하나 이상 존재한다면
                     if self.ready_queue:
-                        input_process = self.ready_queue.pop(0)
-                        cpu.set_process(input_process, cur_time, cur_time + input_process.BT)
+                        cpu.set_process(self.ready_queue.pop(0))
             # 현재시간 증가
             cur_time += 1

--- a/HRRN.py
+++ b/HRRN.py
@@ -21,9 +21,10 @@ class HRRN(Scheduler):
                     AT_idx = process_idx
                     break
 
+            super().work()
             for cpu in self.cpus:
                 # 만약 cpu의 일이 끝났으면, 끝난 프로세스의 output을 저장하고 cpu를 쉬게 한다.
-                if cpu.is_finished(cur_time):
+                if cpu.is_finished():
                     print("process finished - cur_time:", cur_time, " p_id :", cpu.process.process_id)
                     cpu.process.calculate_finished_process(cur_time)
                     finish_processes_count += 1
@@ -39,7 +40,7 @@ class HRRN(Scheduler):
                                 max_response_ratio = response_ratio
                                 next_process = process
                         self.ready_queue.remove(next_process)  # 선택한 프로세스를 대기열 큐에서 삭제
-                        cpu.set_process(next_process, cur_time, cur_time + next_process.BT)
+                        cpu.set_process(next_process)
 
             # ready_queue의 모든 프로세스의 WT를 1씩 추가
             for process in self.ready_queue:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ### Python Coding Convention
 
--   [PEP 8 - Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/)
+- [PEP 8 - Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/)
 
--   [PEP 8 번역본](https://b.luavis.kr/python/python-convention)
+- [PEP 8 번역본](https://b.luavis.kr/python/python-convention)
 
 ### Code formatter
 
--   Prettier
+- Prettier
 
 ---
 
@@ -22,16 +22,16 @@
 
 #### Scheduler (abstarct class)
 
--   속성
-    -   process_count
-    -   process_list
-    -   cpu_count
-    -   cpu_list
-    -   ready_queue
--   메소드
-    -   create_process(self, process_count, AT, BT)
-    -   create_cpu(self, cpu_count)
-    -   run(self)
+- 속성
+  - process_count
+  - process_list
+  - cpu_count
+  - cpu_list
+  - ready_queue
+- 메소드
+  - create_process(self, process_count, AT, BT)
+  - create_cpu(self, cpu_count)
+  - run(self)
 
 ##### FCFS
 

--- a/RR.py
+++ b/RR.py
@@ -23,10 +23,12 @@ class RR(Scheduler):
                     AT_idx = process_idx
                     break
 
+            super().work()
+
             # cpu들을 돌면서
             for cpu in self.cpus:
                 # cpu의 일이 끝났으면
-                if cpu.is_finished(cur_time):
+                if cpu.is_finished(self.quantum):
                     # 만약 프로세스가 실행시간이 남아있으면 다시 대기열 큐에 넣어준다.
                     if cpu.process.remain_BT > 0:
                         self.ready_queue.append(cpu.process)
@@ -44,11 +46,6 @@ class RR(Scheduler):
                 if cpu.is_idle():
                     # 대기열에 프로세스가 하나 이상 존재한다면
                     if self.ready_queue:
-                        input_process = self.ready_queue.pop(0)
-                        # 현재 넣을 프로세스의 남은 실행 시간이 RR의 quantum보다 작으면
-                        # 남은 실행 시간이 일할시간, 아니면 quantum이 일할 시간이 된다.
-                        remain_BT = input_process.remain_BT
-                        work_time = self.quantum if remain_BT >= self.quantum else remain_BT
-                        cpu.set_process(input_process, cur_time, cur_time + work_time)
+                        cpu.set_process(self.ready_queue.pop(0))
             # 현재시간 증가
             cur_time += 1

--- a/SPN.py
+++ b/SPN.py
@@ -18,10 +18,11 @@ class SPN(Scheduler):
                     AT_idx = process_idx
                     break
 
+            super().work()
             # cpu들을 돌면서
             for cpu in self.cpus:
                 # cpu의 일이 끝났으면
-                if cpu.is_finished(cur_time):
+                if cpu.is_finished():
                     print("processe finished - cur_time:", cur_time, " p_id :", cpu.process.process_id)
                     cpu.process.calculate_finished_process(cur_time)
                     finish_processes_count += 1
@@ -30,13 +31,12 @@ class SPN(Scheduler):
                 # cpu가 쉬고 있고
                 if cpu.is_idle():
                     # 대기열에 프로세스가 하나 이상 존재한다면
-                    if len(self.ready_queue) >= 1 :
+                    if self.ready_queue:
                         # 대기열 내의 프로세스 중 BT가 가장 작은 프로세스를 선별하여 cpu에 set
                         process_num = 0
                         for i in range(1,len(self.ready_queue)):
                             if self.ready_queue[i].BT < self.ready_queue[process_num].BT:
                                 process_num = i
-                        input_process = self.ready_queue.pop(process_num)
-                        cpu.set_process(input_process, cur_time, cur_time + input_process.BT)
+                        cpu.set_process(self.ready_queue.pop(process_num))
             # 현재시간 증가
             cur_time += 1

--- a/SRTN.py
+++ b/SRTN.py
@@ -1,37 +1,31 @@
 from Scheduler import *
 
 class SRTN(Scheduler):
-    def __init__(self,process_input_list,cpu_count):
-        super().__init__(process_input_list,cpu_count)
-
     def run(self):
         cur_time=0 #시간 증가
         AT_idx=0
         finished_processes_count=0 #종료된 프로세스 = 총 프로세스
 
-        sorted_processes=sorted(self.processes,key=lambda x:x.AT) 
+        sorted_processes=sorted(self.processes,key=lambda x:x.AT)
 
-        start=False
         while(finished_processes_count<self.process_count):
             for process_idx in range(AT_idx,self.process_count):
-                process=sorted_processes[process_idx] 
-                
+                process=sorted_processes[process_idx]
+
                 if process.AT==cur_time:
                     print("process arrived - cur_time: ", cur_time,"p_id: ",process.process_id)
-                    self.ready_queue.append(process) 
+                    self.ready_queue.append(process)
 
                 elif process.AT>cur_time:
-                    AT_idex=process_idx
+                    AT_idx=process_idx
                     break
-            if start is True:
-                for cpu in self.cpus:
-                    if cpu.process is not None:
-                        cpu.process.remain_BT-=1
+
+            super().work()
 
             for cpu in self.cpus:
                 self.ready_queue=sorted(self.ready_queue,key=lambda x:x.remain_BT)
-                #종료된 거 있을 때 남은 remain_BT==0인 경우 => cpu free  
-                if cpu.process is not None and cpu.process.remain_BT==0:
+                #종료된 거 있을 때 남은 remain_BT==0인 경우 => cpu free
+                if cpu.is_finished():
                         cpu.process.calculate_finished_process(cur_time)
                         finished_processes_count+=1
                         cpu.set_idle() #현재 cpu free
@@ -40,11 +34,10 @@ class SRTN(Scheduler):
                     if self.ready_queue:
                         next_process=self.ready_queue.pop(0)
                         cpu.process=next_process
-                        start=True
-    
+
             #ready_queue랑 cpu의 remain_bt랑 비교
 
-            if self.ready_queue:#ready_queue가 있으면 그 후 비교 
+            if self.ready_queue:#ready_queue가 있으면 그 후 비교
                 for cpu in self.cpus:
                     idx=-1
                     for i in range (len(self.ready_queue)):
@@ -52,6 +45,6 @@ class SRTN(Scheduler):
                             idx=i
                     if idx!=-1:
                         self.ready_queue.append(cpu.process)
-                        cpu.process=self.ready_queue.pop(idx)
-                            
+                        cpu.set_process(self.ready_queue.pop(idx))
+
             cur_time+=1

--- a/Scheduler.py
+++ b/Scheduler.py
@@ -23,6 +23,12 @@ class Scheduler(metaclass=ABCMeta):
             cpu_list.append(CPU(i + 1))
         return cpu_list
 
+    def work(self):
+        for cpu in self.cpus:
+            if not cpu.is_idle():
+                cpu.process.remain_BT -= 1
+                cpu.work_time += 1
+
     @abstractmethod
     def run(self):
         pass


### PR DESCRIPTION
원래 end_time을 정해주는 로직이였는데 SRTN 스케줄러에서 실시간으로 남은 실행시간을 계산해야돼서 남은 실행시간을 실시간으로 계산해주는 로직으로 통일해서 바꾸었습니다.