### PR TITLE
오류 수정: GUI 오류 해결 및 스케줄링 알고리즘 수정

### DIFF
--- a/FCFS.py
+++ b/FCFS.py
@@ -9,24 +9,26 @@ class FCFS(Scheduler):
         sorted_processes = sorted(self.processes, key=lambda x: x.AT)
         # 끝난 프로세스가 총 프로세스의 수와 같아질때까지 작동
         while finish_processes_count < self.process_count:
-            super().work()
-
             # 현재 시간에 도착할 프로세스 대기열 큐에 넣어주기
             for process_idx in range(AT_idx, self.process_count):
                 process = sorted_processes[process_idx]
                 if process.AT == cur_time:
-                    print("processe arrived - cur_time:", cur_time, " p_id :", process.process_id)
+                    print("process arrived - cur_time:", cur_time, " p_id :", process.process_id)
                     self.ready_queue.append(process)
                 elif process.AT > cur_time:
                     AT_idx = process_idx
                     break
+                
+            # history 기록하기
+            self.record_history(self.ready_queue[:], self.cpus, self.processes)
+
             # cpu들을 돌면서
             for cpu in self.cpus:
                 # cpu의 일이 끝났으면
                 if cpu.is_finished():
                     # 프로세스가 완전히 끝나면 현재시간을 기준으로 각 time을 계산
                     # 끝난 프로세스의 개수 1 증가
-                    print("processe finished - cur_time:", cur_time, " p_id :", cpu.process.process_id)
+                    print("process finished - cur_time:", cur_time, " p_id :", cpu.process.process_id)
                     cpu.process.calculate_finished_process(cur_time)
                     finish_processes_count += 1
                     # 일이 끝난 CPU는 쉬게 해준다.
@@ -37,8 +39,12 @@ class FCFS(Scheduler):
                     # 대기열에 프로세스가 하나 이상 존재한다면
                     if self.ready_queue:
                         cpu.set_process(self.ready_queue.pop(0))
-            # history 기록하기
-            self.record_history(self.ready_queue[:], self.cpus, self.processes)
+
+            for process in self.processes:
+                process.calculate_finished_process(cur_time)
+                # print(process.AT, process.BT, process.WT, process.TT)
+
 
             # 현재시간 증가
+            super().work()
             cur_time += 1

--- a/HRRN.py
+++ b/HRRN.py
@@ -11,8 +11,6 @@ class HRRN(Scheduler):
         AT_idx = 0
         sorted_processes = sorted(self.processes, key=lambda x: x.AT)
         while finish_processes_count < self.process_count:
-            super().work()
-
             # 현재 시간과 AT가 일치하는 프로세스를 대기열 큐에 넣어주기
             for process_idx in range(AT_idx, self.process_count):
                 process = sorted_processes[process_idx]
@@ -22,6 +20,9 @@ class HRRN(Scheduler):
                 elif process.AT > cur_time:  # 더이상 검사할 필요가 없으므로 종료
                     AT_idx = process_idx
                     break
+
+            # history 기록하기
+            self.record_history(self.ready_queue[:], self.cpus, self.processes)
 
             for cpu in self.cpus:
                 # 만약 cpu의 일이 끝났으면, 끝난 프로세스의 output을 저장하고 cpu를 쉬게 한다.
@@ -43,12 +44,10 @@ class HRRN(Scheduler):
                         self.ready_queue.remove(next_process)  # 선택한 프로세스를 대기열 큐에서 삭제
                         cpu.set_process(next_process)
 
-            # history 기록하기
-            self.record_history(self.ready_queue[:], self.cpus, self.processes)
-
             # ready_queue의 모든 프로세스의 WT를 1씩 추가
             for process in self.ready_queue:
                 process.WT += 1
 
             # 현재 시간 1 증가
             cur_time += 1
+            super().work()

--- a/RR.py
+++ b/RR.py
@@ -13,8 +13,6 @@ class RR(Scheduler):
         sorted_processes = sorted(self.processes, key=lambda x: x.AT)
         # 끝난 프로세스가 총 프로세스의 수와 같아질때까지 작동
         while finish_processes_count < self.process_count:
-            super().work()
-
             # 현재 시간에 도착할 프로세스 대기열 큐에 넣어주기
             for process_idx in range(AT_idx, self.process_count):
                 process = sorted_processes[process_idx]
@@ -24,6 +22,9 @@ class RR(Scheduler):
                 elif process.AT > cur_time:
                     AT_idx = process_idx
                     break
+
+            # history 기록하기
+            self.record_history(self.ready_queue[:], self.cpus, self.processes)
 
             # cpu들을 돌면서
             for cpu in self.cpus:
@@ -48,8 +49,6 @@ class RR(Scheduler):
                     if self.ready_queue:
                         cpu.set_process(self.ready_queue.pop(0))
 
-            # history 기록하기
-            self.record_history(self.ready_queue[:], self.cpus, self.processes)
-
             # 현재시간 증가
             cur_time += 1
+            super().work()

--- a/SPN.py
+++ b/SPN.py
@@ -9,8 +9,6 @@ class SPN(Scheduler):
         sorted_processes = sorted(self.processes, key=lambda x: x.AT)
         # 끝난 프로세스가 총 프로세스의 수와 같아질때까지 작동
         while finish_processes_count < self.process_count:
-            super().work()
-
             # 현재 시간에 도착할 프로세스 대기열 큐에 넣어주기
             for process_idx in range(AT_idx, self.process_count):
                 process = sorted_processes[process_idx]
@@ -20,6 +18,9 @@ class SPN(Scheduler):
                 elif process.AT > cur_time:
                     AT_idx = process_idx
                     break
+
+            # history 기록하기
+            self.record_history(self.ready_queue[:], self.cpus, self.processes)
 
             # cpu들을 돌면서
             for cpu in self.cpus:
@@ -41,8 +42,7 @@ class SPN(Scheduler):
                                 process_num = i
                         cpu.set_process(self.ready_queue.pop(process_num))
 
-            # history 기록하기
-            self.record_history(self.ready_queue[:], self.cpus, self.processes)
-
             # 현재시간 증가
             cur_time += 1
+            super().work()
+

--- a/SRTN.py
+++ b/SRTN.py
@@ -23,7 +23,8 @@ class SRTN(Scheduler):
                     AT_idx = process_idx
                     break
 
-            super().work()
+            # history 기록하기
+            self.record_history(self.ready_queue[:], self.cpus, self.processes)
 
             for cpu in self.cpus:
                 self.ready_queue = sorted(self.ready_queue, key=lambda x: x.remain_BT)
@@ -63,7 +64,5 @@ class SRTN(Scheduler):
                     else:
                         break
 
-            # history 기록하기
-            self.record_history(self.ready_queue[:], self.cpus, self.processes)
-
             cur_time += 1
+            super().work()

--- a/show.py
+++ b/show.py
@@ -210,8 +210,6 @@ class MyApp(QWidget):
             self.Proc_Table.item(i, 0).setBackground(
                 QtGui.QColor(self.Proc_List[i].Color[0], self.Proc_List[i].Color[1], self.Proc_List[i].Color[2])
             )
-            # if self.Proc_List[i].Color[0] + self.Proc_List[i].Color[1] + self.Proc_List[i].Color[2] < 350:
-            #     self.Proc_Table.item(i, 0).setForeground(QtGui.QBrush(QtGui.QColor(255, 255, 255)))
             self.Proc_Table.setItem(i, 1, QTableWidgetItem(str(self.Proc_List[i].AT)))
             self.Proc_Table.setItem(i, 2, QTableWidgetItem(str(self.Proc_List[i].BT)))
         # 초기화 부분
@@ -230,8 +228,6 @@ class MyApp(QWidget):
             self.Proc_Table.item(i, 0).setBackground(
                 QtGui.QColor(self.Proc_List[i].Color[0], self.Proc_List[i].Color[1], self.Proc_List[i].Color[2])
             )
-            # if self.Proc_List[i].Color[0] + self.Proc_List[i].Color[1] + self.Proc_List[i].Color[2] < 350:
-            #     self.Proc_Table.item(i, 0).setForeground(QtGui.QBrush(QtGui.QColor(255, 255, 255)))
             self.Proc_Table.setItem(i, 1, QTableWidgetItem(str(self.Proc_List[i].AT)))
             self.Proc_Table.setItem(i, 2, QTableWidgetItem(str(self.Proc_List[i].BT)))
         # 초기화 부분
@@ -283,31 +279,42 @@ class MyApp(QWidget):
         self.history_slider.setValue(0)
         # 이후 함수들은 0초를 기준으로 화면에 띄우는것, slider_Control과 거이 동일하기 때문에 거기에 주석을 달겠습니다.
         self.Ready_Table.setColumnCount(len(self.history[0][0]))
-        print("Debug:", len(self.history))
         self.Gantt_Table.setColumnCount(0)
         self.Result_Table.setRowCount(len(self.history[0][2]))
-        for Q_process in range(len(self.history[0][0])):
-            self.Ready_Table.setItem(0, Q_process, QTableWidgetItem(self.history[0][0][Q_process].process_id))
-            self.Ready_Table.item(0, Q_process).setBackground(
+
+        ready_queue_count = len(self.history[0][0])
+        cpu_count = len(self.history[0][1])
+        process_count = len(self.history[0][2])
+
+        for queue_process_idx in range(ready_queue_count):
+            self.Ready_Table.setItem(
+                0, queue_process_idx, QTableWidgetItem(self.history[0][0][queue_process_idx].process_id)
+            )
+            self.Ready_Table.item(0, queue_process_idx).setBackground(
                 QtGui.QColor(
-                    self.history[0][0][Q_process].Color[0],
-                    self.history[0][0][Q_process].Color[1],
-                    self.history[0][0][Q_process].Color[2],
+                    self.history[0][0][queue_process_idx].Color[0],
+                    self.history[0][0][queue_process_idx].Color[1],
+                    self.history[0][0][queue_process_idx].Color[2],
                 )
             )
-        for cpu in range(len(self.history[0][1])):
-            if self.history[0][1][cpu]:
-                print("CHECK:", self.history[0][1][cpu].process_id)
-                self.Gantt_Table.setItem(cpu, 0, QTableWidgetItem(self.history[0][1][cpu].process_id))
-                if self.Gantt_Table.item(cpu, 0):
-                    self.Gantt_Table.item(cpu, 0).setBackground(
-                        QtGui.QColor(
-                            self.history[0][1][cpu].Color[0],
-                            self.history[0][1][cpu].Color[1],
-                            self.history[0][1][cpu].Color[2],
-                        )
-                    )
-        for process in range(len(self.history[0][2])):
+            # DEBUG
+            # print("queue:", self.history[0][0][queue_process_idx].process_id)
+
+        # 처음에는 간트 차트 출력 X
+        # for cpu in range(cpu_count):
+        #     if self.history[1][1][cpu]:
+        #         print("CHECK:", self.history[1][1][cpu].process_id)
+        #         self.Gantt_Table.setItem(cpu, 0, QTableWidgetItem(self.history[1][1][cpu].process_id))
+        #         self.Gantt_Table.item(cpu, 0).setBackground(
+        #             QtGui.QColor(
+        #                 self.history[1][1][cpu].Color[0],
+        #                 self.history[1][1][cpu].Color[1],
+        #                 self.history[1][1][cpu].Color[2],
+        #             )
+        #         )
+        # print("gantt:", self.history[0][1][cpu].process_id)
+
+        for process in range(process_count):
             self.Result_Table.setItem(process, 0, QTableWidgetItem(self.history[0][2][process].process_id))
             self.Result_Table.setItem(process, 1, QTableWidgetItem(str(self.history[0][2][process].AT)))
             self.Result_Table.setItem(process, 2, QTableWidgetItem(str(self.history[0][2][process].BT)))
@@ -321,6 +328,8 @@ class MyApp(QWidget):
                     self.history[0][2][process].Color[2],
                 )
             )
+            # print("result:", self.history[0][2][process].process_id)
+
         self.Ready_Table.repaint()
         self.Gantt_Table.repaint()
         self.Result_Table.repaint()
@@ -328,52 +337,64 @@ class MyApp(QWidget):
     def slider_Control(self):
         # 초 = 슬라이더의 값
         second = self.history_slider.value()
+        ready_queue_count = len(self.history[second][0])
+        cpu_count = len(self.history[0][1])
+        process_count = len(self.history[0][2])
+
         # 표의 너비 지정
         self.Ready_Table.setColumnCount(len(self.history[second][0]))
         self.Gantt_Table.setColumnCount(second)
         self.Result_Table.setRowCount(len(self.history[second][2]))
         # 레디 큐에 저장된 프로세스를 Ready_Table에 넣는 과정
-        for Q_process in range(len(self.history[second][0])):
-            self.Ready_Table.setItem(0, Q_process, QTableWidgetItem(self.history[second][0][Q_process].process_id))
-            self.Ready_Table.item(0, Q_process).setBackground(
+        for queue_process_idx in range(ready_queue_count):
+            self.Ready_Table.setItem(
+                0, queue_process_idx, QTableWidgetItem(self.history[second][0][queue_process_idx].process_id)
+            )
+            self.Ready_Table.item(0, queue_process_idx).setBackground(
                 QtGui.QColor(
-                    self.history[second][0][Q_process].Color[0],
-                    self.history[second][0][Q_process].Color[1],
-                    self.history[second][0][Q_process].Color[2],
+                    self.history[second][0][queue_process_idx].Color[0],
+                    self.history[second][0][queue_process_idx].Color[1],
+                    self.history[second][0][queue_process_idx].Color[2],
+                )
+            )
+            # print("queue:", self.history[second][0][queue_process_idx].process_id)
+
+        # ==================================================================
+        # history CPU를 매초마다 탐색해서 CPU내에 들어간 프로세스를 넣는 과정
+        for seconds in range(second):
+            for cpu in range(cpu_count):
+                # CPU가 쉬는 도중에는 할당될 프로세스가 없을 가능성 존재
+                if self.history[seconds + 1][1][cpu]:
+                    self.Gantt_Table.setItem(
+                        cpu, seconds, QTableWidgetItem(self.history[seconds + 1][1][cpu].process_id)
+                    )
+                    # 이거 if 안넣으면 NoneType떠서 넣긴했는데 이유 솔직히 모르겠음.. 저도 모르겠네요...
+                    self.Gantt_Table.item(cpu, seconds).setBackground(
+                        QtGui.QColor(
+                            self.history[seconds + 1][1][cpu].Color[0],
+                            self.history[seconds + 1][1][cpu].Color[1],
+                            self.history[seconds + 1][1][cpu].Color[2],
+                        )
+                    )
+
+            # print("gantt:", self.history[seconds][1][cpu].process_id)
+        # 결과 테이블에 프로세스의 현황을 넣는 과정, 근데 계산 끝난 결과로만 출력이 되는데 왜 그러는지 잘 모르겠음.
+        # 굳이 매초마다 갱신할 필요가 없으면 슬라이더 옮길때마다 매번 갱신할 필요가 없어서 이부분은 지워도 괜찮음.
+        for process in range(process_count):
+            self.Result_Table.setItem(process, 0, QTableWidgetItem(self.history[second][2][process].process_id))
+            self.Result_Table.setItem(process, 1, QTableWidgetItem(str(self.history[second][2][process].AT)))
+            self.Result_Table.setItem(process, 2, QTableWidgetItem(str(self.history[second][2][process].BT)))
+            self.Result_Table.setItem(process, 3, QTableWidgetItem(str(self.history[second][2][process].WT)))
+            self.Result_Table.setItem(process, 4, QTableWidgetItem(str(self.history[second][2][process].TT)))
+            self.Result_Table.setItem(process, 5, QTableWidgetItem(str(self.history[second][2][process].NTT)))
+            self.Result_Table.item(process, 0).setBackground(
+                QtGui.QColor(
+                    self.history[second][2][process].Color[0],
+                    self.history[second][2][process].Color[1],
+                    self.history[second][2][process].Color[2],
                 )
             )
 
-        # history CPU를 매초마다 탐색해서 CPU내에 들어간 프로세스를 넣는 과정
-        for seconds in range(0, second + 1):
-            for cpu in range(len(self.history[0][1])):
-                # CPU가 쉬는 도중에는 할당될 프로세스가 없을 가능성 존재
-                if self.history[seconds][1][cpu]:
-                    self.Gantt_Table.setItem(cpu, seconds, QTableWidgetItem(self.history[seconds][1][cpu].process_id))
-                    # 이거 if 안넣으면 NoneType떠서 넣긴했는데 이유 솔직히 모르겠음.. 저도 모르겠네요...
-                    if self.Gantt_Table.item(cpu, seconds):
-                        self.Gantt_Table.item(cpu, seconds).setBackground(
-                            QtGui.QColor(
-                                self.history[seconds][1][cpu].Color[0],
-                                self.history[seconds][1][cpu].Color[1],
-                                self.history[seconds][1][cpu].Color[2],
-                            )
-                        )
-        # 결과 테이블에 프로세스의 현황을 넣는 과정, 근데 계산 끝난 결과로만 출력이 되는데 왜 그러는지 잘 모르겠음.
-        # 굳이 매초마다 갱신할 필요가 없으면 슬라이더 옮길때마다 매번 갱신할 필요가 없어서 이부분은 지워도 괜찮음.
-        # for process in range(len(self.history[0][2])):
-        #     self.Result_Table.setItem(process, 0, QTableWidgetItem(self.history[second][2][process].process_id))
-        #     self.Result_Table.setItem(process, 1, QTableWidgetItem(str(self.history[second][2][process].AT)))
-        #     self.Result_Table.setItem(process, 2, QTableWidgetItem(str(self.history[second][2][process].BT)))
-        #     self.Result_Table.setItem(process, 3, QTableWidgetItem(str(self.history[second][2][process].WT)))
-        #     self.Result_Table.setItem(process, 4, QTableWidgetItem(str(self.history[second][2][process].TT)))
-        #     self.Result_Table.setItem(process, 5, QTableWidgetItem(str(self.history[second][2][process].NTT)))
-        #     self.Result_Table.item(process, 0).setBackground(
-        #         QtGui.QColor(
-        #             self.history[second][2][process].Color[0],
-        #             self.history[second][2][process].Color[1],
-        #             self.history[second][2][process].Color[2],
-        #         )
-        #     )
         self.Ready_Table.repaint()
         self.Gantt_Table.repaint()
         self.Result_Table.repaint()


### PR DESCRIPTION
### GUI 오류 해결
- CPU 2개 이상일 때 빈칸에 프로세스 입력되는 문제 해결
- run 누르자마자 뜨는 화면에서는 간트차트는 출력될 필요 없으므로 주석 처리함
- ready_queue와 간트 차트를 history에 저장하는 시점이 1초씩 차이가 나는 문제 해결 - `seconds+1`번째 history를 간트차트의 `second`번째열에 출력  
→ show.py의 367~369줄 확인
→ `self.Gantt_Table.setItem(cpu, seconds, QTableWidgetItem(self.history[seconds + 1][1][cpu].process_id)`

### 스케줄링 알고리즘 수정
- `super_work()`가 `cur_time += 1`와 같이 수행되도록 옮김
- history 저장 시점을 중앙으로 옮김(이렇게 해야 간트차트, 레디 큐의 출력이 제대로 됨)