### PR TITLE
GUI 현재 수정 내역

### DIFF
--- a/Process.py
+++ b/Process.py
@@ -2,7 +2,7 @@ import random
 
 
 class Process:
-    def __init__(self, process_id, AT, BT, color_idx):
+    def __init__(self, process_id, AT, BT, color_idx, sel_CPU = None):
         self.process_id = process_id
         self.AT = AT  # arrival time
         self.BT = BT  # burst time
@@ -10,7 +10,7 @@ class Process:
         self.WT = 0  # waiting time(TT - BT)
         self.TT = 0  # turnaround time
         self.NTT = 0  # normalized turnaround time(TT/BT)
-
+        self.select_CPU = sel_CPU
         # 수정 : color_palette 추가
         self.color_palette = [
             [255, 200, 162],

--- a/show.py
+++ b/show.py
@@ -17,6 +17,8 @@ class MyApp(QWidget):
         self.Run_Start = False
         self.algo_list = ["FCFS", "RR", "SPN", "SRTN", "HRRN", "YOSA"]
         self.column_count = 3
+        self.cur_algo = "FCFS"
+        self.proc_Count = [0] * 4
         self.initUI()
 
     # 수정 : font
@@ -44,11 +46,14 @@ class MyApp(QWidget):
         # AT와 BT같이 사용자에게 숫자로만 받을거라면 스핀박스로 하는게 더 편하다고 함
         self.ProName = QLineEdit()
         self.ProName.setMaxLength(10)
+        self.ATLabel = QLabel("AT")
         self.AT = QSpinBox()
         self.AT.setRange(0, 65535)
         self.BT = QSpinBox()
         self.BT.setRange(1, 65535)
-
+        self.StudentList = QComboBox(self)
+        self.StudentList.addItem("학생 1")
+        self.StudentList.setDisabled(True)
         # 프로세스 목록을 표로 보여줄 Proc_Table선언
         self.Proc_Table = QTableWidget(self)
         self.Proc_Table.setColumnCount(3)
@@ -64,6 +69,7 @@ class MyApp(QWidget):
         for cpu_idx in range(1, 5):
             self.cpu_count.addItem(str(cpu_idx))
         self.cpu_count.activated.connect(self.setCPUTable_slot)
+        self.CPULabel = QLabel("CPU")
 
         # Ready Queue 보여줄 테이블
         self.Ready_Table = QTableWidget(self)
@@ -85,6 +91,11 @@ class MyApp(QWidget):
         self.TQ = QSpinBox()
         self.TQ.setRange(1, 65535)
         self.TQ.setDisabled(True)
+        self.TQLabel = QLabel("Quantum")
+
+        self.TP_Time = QSpinBox()
+        self.TP_Time.setRange(1,24)
+        self.TP_Time.setDisabled(True)
 
         # Gantt Chart를 표로 보여줄 Result_Table선언
         self.Result_Table = QTableWidget(self)
@@ -98,10 +109,10 @@ class MyApp(QWidget):
             header.setSectionResizeMode(time_table_col, QHeaderView.Stretch)
 
         # Proc_List에 프로세스 목록을 추가 및 화면 내용을 리셋하는 버튼 (이때문에 거진 뒤로 가야할듯)
-        addButton = QPushButton("Add", self)
+        self.addButton = QPushButton("Add", self)
         # addButton.clicked.connect(self.add)
         # 수정 : 디버깅용 test를 add 버튼에 일시적으로 연결 (test 누르면 자동으로 값 입력됨)
-        addButton.clicked.connect(self.test)
+        self.addButton.clicked.connect(self.add)
 
         resetButton = QPushButton("Reset", self)
         resetButton.clicked.connect(self.reset)
@@ -120,22 +131,26 @@ class MyApp(QWidget):
         grid_Line1 = QGridLayout()
         grid_Line1.addWidget(QLabel("Algorithm"), 0, 0)
         grid_Line1.addWidget(QLabel("Process Name"), 0, 1)
-        grid_Line1.addWidget(QLabel("AT"), 0, 2)
+        grid_Line1.addWidget(self.ATLabel, 0, 2)
         grid_Line1.addWidget(QLabel("BT"), 0, 3)
         grid_Line1.addWidget(self.Alg_Select, 1, 0)
         grid_Line1.addWidget(self.ProName, 1, 1)
         grid_Line1.addWidget(self.AT, 1, 2)
         grid_Line1.addWidget(self.BT, 1, 3)
-        grid_Line1.addWidget(addButton, 1, 4)
-        grid_Line1.addWidget(resetButton, 1, 5)
+        grid_Line1.addWidget(QLabel("대상 학생"),0,4)
+        grid_Line1.addWidget(self.StudentList,1,4)
+        grid_Line1.addWidget(self.addButton, 1, 5)
+        grid_Line1.addWidget(resetButton, 1, 6)
 
         # 두번째 줄 오른편의 그리드, cpu_count, TQ, Run_Alg, Stop_Alg을 그리드 레이아웃에 추가
         grid_Line2 = QGridLayout()
-        grid_Line2.addWidget(QLabel("CPU"), 0, 0)
+        grid_Line2.addWidget(self.CPULabel, 0, 0)
         grid_Line2.addWidget(self.cpu_count, 0, 1)
-        grid_Line2.addWidget(QLabel("Quantum"), 1, 0)
+        grid_Line2.addWidget(self.TQLabel, 1, 0)
         grid_Line2.addWidget(self.TQ, 1, 1)
-        grid_Line2.addWidget(self.Run_Alg, 2, 0)
+        grid_Line2.addWidget(QLabel("팀프 시간"),2,0)
+        grid_Line2.addWidget(self.TP_Time,2,1)
+        grid_Line2.addWidget(self.Run_Alg, 3, 0)
 
         # 두번째 줄을 통합해줄 hbox_Line2, Proc_Table과 grid_Line2를 레이아웃에 추가함.
         hbox_Line2 = QHBoxLayout()
@@ -178,19 +193,45 @@ class MyApp(QWidget):
         self.move(qr.topLeft())
 
     def enableSlot(self):
-        if self.Alg_Select.currentText() == "RR":
-            self.TQ.setEnabled(True)
+        if self.Alg_Select.currentText() == "YOSA":
+            self.reset()
+            # 화면을 YOSA용 세팅으로 변경
+            self.YOSASetting()
         else:
-            self.TQ.setDisabled(True)
+            # 이전 세팅이 YOSA 였다면
+            if self.cur_algo == "YOSA":
+                self.reset()
+                # 화면을 기본 세팅으로 바꿈
+                self.defaultSetting()
+            if self.Alg_Select.currentText() == "RR":
+                self.TQ.setEnabled(True)
+            else:
+                self.TQ.setDisabled(True)
+        self.cur_algo = self.Alg_Select.currentText() 
 
     def setCPUTable_slot(self):
         NameHeader = []
         CPU_Select = int(self.cpu_count.currentText())
         self.Gantt_Table.setRowCount(CPU_Select)
-
-        for i in range(1, CPU_Select + 1):
-            NameHeader.append("CPU " + str(i))
-
+        if self.Alg_Select.currentText() == "YOSA":
+            for i in range(1, CPU_Select + 1):
+                NameHeader.append("학생 " + str(i))
+            # CPU에 개수에 따라 변동되는 내역들은 전부 여기에 있다고 생각하면 편함
+            self.Result_Table.setRowCount(CPU_Select)
+            self.Result_Table.verticalHeader().setVisible(True)
+            self.Result_Table.setVerticalHeaderLabels(NameHeader)
+            header = self.Result_Table.verticalHeader()
+            for i in range(len(NameHeader)):
+                header.setSectionResizeMode(i, QHeaderView.Stretch)
+            # 팀프의 최대 시간은 학생의 수 * 24
+            self.TP_Time.setRange(1,CPU_Select*24)
+            self.StudentList.clear()
+            for i in range(1, CPU_Select + 1):
+                self.StudentList.addItem("학생 " + str(i))
+        else:
+            for i in range(1, CPU_Select + 1):
+                NameHeader.append("CPU " + str(i))
+        # 간트차트 정렬 하는거
         self.Gantt_Table.setVerticalHeaderLabels(NameHeader)
         header = self.Gantt_Table.verticalHeader()
         for i in range(len(NameHeader)):
@@ -248,7 +289,28 @@ class MyApp(QWidget):
     def add(self):
         self.Run_Alg.setEnabled(True)
         # Proc_List에 프로세스를 저장.
-        self.Proc_List.append(Process(self.ProName.text(), self.AT.value(), self.BT.value()))
+        if self.cur_algo != "YOSA":
+            self.Proc_List.append(Process(self.ProName.text(), self.AT.value(), self.BT.value()))
+        # YOSA인 경우 해당되는 CPU의 정보도 같이 넣어줌
+        else:
+            # select에 선택한 학생 번호를 넣어주고, 이를 Proc_List에 넣을떄 같이 넣어줌
+            select = int(self.StudentList.currentText()[-1])
+            self.Proc_List.append(Process(self.ProName.text(), self.AT.value(), self.BT.value(), random.randrange(1, 15), select))
+            self.proc_Count[select -  1] += 1
+            # 만약 학생 3이 해야하는 프로세스가 등록이 되었을 때, 이후 학생 수를 1이나 2로 선정하고 run을 돌리면 문제가 될 것.
+            # 이를 보완하기 위해 학생 3이 해야하는 프로세스가 등록이 되면 학생수 1이나 2를 비활성화 하함
+            while(int(self.cpu_count.itemText(0)) < select):
+                  self.cpu_count.removeItem(0)
+            # 만약 해당 학생의 프로세스 개수가 4가 되면 StudentList의 해당 학생을 빼서 더이상 넣지 못하게 함
+            # 그리고 그런 상황에서 cpu_count 건들면 괜히 이상해질거같으니 cpu_count 비활성화 
+            if self.proc_Count[select -  1] == 4:
+                find = "학생 " + str(select)
+                deleteIndex = self.StudentList.findText(find)
+                self.StudentList.removeItem(deleteIndex)
+                self.cpu_count.setDisabled(True)
+            # 위에 하면서 StudentList 내용 지우다가 내용 싹다 없어지면 addbutton 비활성화
+            if self.StudentList.count() == 0:
+                self.addButton.setDisabled(True)
         # 이후 Proc_Table에 프로세스를 띄우도록 함, 열크기 = Proc_List 크기
         self.Proc_Table.setRowCount(len(self.Proc_List))
         for i in range(len(self.Proc_List)):
@@ -258,10 +320,13 @@ class MyApp(QWidget):
             )
             self.Proc_Table.setItem(i, 1, QTableWidgetItem(str(self.Proc_List[i].AT)))
             self.Proc_Table.setItem(i, 2, QTableWidgetItem(str(self.Proc_List[i].BT)))
+            if self.cur_algo == "YOSA":
+                # YOSA인 경우엔 select_CPU값도 넣어줌
+                self.Proc_Table.setItem(i, 3, QTableWidgetItem("학생 " + str(self.Proc_List[i].select_CPU)))
         # 초기화 부분
         self.ProName.clear()
         self.AT.setValue(0)
-        self.BT.setValue(0)
+        self.BT.setValue(1)
 
     def reset(self):
         # Proc_Table과 Result_Table 열을 0으로 만들고 Proc_List를 clear
@@ -277,6 +342,16 @@ class MyApp(QWidget):
         self.Proc_List.clear()
         self.history.clear()
         self.history_slider.setDisabled(True)
+        self.addButton.setEnabled(True)
+        # YOSA에서 학생 목록 지워버린것도 고려해야해서 setCPUTable_slot 넣었음
+        self.setCPUTable_slot()
+        self.cpu_count.setEnabled(True)
+        # cpu_count 건드리는 일이 있다면, 이것도 같이 써두는 것이 나을 것이라 생각함.
+        self.cpu_count.clear()
+        for cpu_idx in range(1, 5):
+            self.cpu_count.addItem(str(cpu_idx))
+        for i in range(len(self.proc_Count)):
+            self.proc_Count[i] = 0
 
     # 알고리즘 실행
     def Run_Algorithm(self):
@@ -410,28 +485,80 @@ class MyApp(QWidget):
         self.Gantt_Table.scrollToItem(self.Gantt_Table.item(max_len_cpu, second - 1))
         # 결과 테이블에 프로세스의 현황을 넣는 과정, 근데 계산 끝난 결과로만 출력이 되는데 왜 그러는지 잘 모르겠음.
         # 굳이 매초마다 갱신할 필요가 없으면 슬라이더 옮길때마다 매번 갱신할 필요가 없어서 이부분은 지워도 괜찮음.
-        for process in range(process_count):
-            self.Result_Table.setItem(process, 0, QTableWidgetItem(self.history[second][2][process].process_id))
-            self.Result_Table.setItem(process, 1, QTableWidgetItem(str(self.history[second][2][process].AT)))
-            self.Result_Table.setItem(process, 2, QTableWidgetItem(str(self.history[second][2][process].BT)))
-            self.Result_Table.setItem(process, 3, QTableWidgetItem(str(self.history[second][2][process].WT)))
-            self.Result_Table.setItem(process, 4, QTableWidgetItem(str(self.history[second][2][process].TT)))
-            self.Result_Table.setItem(process, 5, QTableWidgetItem(str(self.history[second][2][process].NTT)))
-            self.Result_Table.item(process, 0).setBackground(
-                QtGui.QColor(
-                    self.history[second][2][process].Color[0],
-                    self.history[second][2][process].Color[1],
-                    self.history[second][2][process].Color[2],
-                )
-            )
 
         self.Ready_Table.repaint()
         self.Gantt_Table.repaint()
-        self.Result_Table.repaint()
+       
         # 경과시간 표시하는 라벨 수정하는거
-        fortext = "Real Time = " + str(second) + " sec"
-        self.realTimeLabel.setText(fortext)
+        if Alg_Select.currentText() == "YOSA":
+            fortext = "Real Time = " + str(second) + " hour"
+            self.realTimeLabel.setText(fortext)
+        else:
+            fortext = "Real Time = " + str(second) + " sec"
+            self.realTimeLabel.setText(fortext)
         self.realTimeLabel.repaint()
+
+    def defaultSetting(self):
+        # AT BT 범위 바꾼거 수정
+        self.AT.setRange(0, 65535)
+        self.ATLabel.setText("AT")
+        self.BT.setRange(1, 65535)
+        self.CPULabel.setText("CPU")
+        self.TQ.setRange(1, 65535)
+        self.TQLabel.setText("Quantum")
+        # Proc_Table 기본 세팅
+        self.Proc_Table.setColumnCount(3)
+        self.Proc_Table.setHorizontalHeaderLabels(["Process Name", "Arrival Time", "Burst Time"])
+        header = self.Proc_Table.horizontalHeader()
+        for column_idx in range(self.column_count):
+            header.setSectionResizeMode(column_idx, QHeaderView.Stretch)
+        # Gantt Table 기본 세팅
+        self.setCPUTable_slot()
+        # Result_Table 기본 세팅
+        self.Result_Table.setColumnCount(6)
+        self.Result_Table.setHorizontalHeaderLabels(
+            ["Process Name", "Arrival Time", "Burst Time", "Waiting Time", "Turnaround Time", "Normalized TT"]
+        )
+        self.Result_Table.verticalHeader().setVisible(False)
+        header = self.Result_Table.horizontalHeader()
+        for time_table_col in range(6):
+            header.setSectionResizeMode(time_table_col, QHeaderView.Stretch)
+        self.realTimeLabel.setText("Real Time = 0 sec")
+        self.StudentList.setDisabled(True)
+        self.TP_Time.setDisabled(True)
+
+    def YOSASetting(self):
+        # AT BT 범위 바꾼거 수정
+        self.AT.setRange(1, 4)
+        self.ATLabel.setText("학점")
+        self.BT.setRange(1, 24)
+        self.CPULabel.setText("학생 수")
+        self.TQ.setRange(1, 4)
+        self.TQLabel.setText("팀프 학점")
+        # Proc_Table 기본 세팅
+        self.Proc_Table.setColumnCount(4)
+        self.Proc_Table.setHorizontalHeaderLabels(["과목 이름", "학점", "소요 시간", "대상 인원"])
+        header = self.Proc_Table.horizontalHeader()
+        for column_idx in range(4):
+            header.setSectionResizeMode(column_idx, QHeaderView.Stretch)
+        # Gantt Table 기본 세팅
+        # 이건 setCPU 여기서 바꿔야할듯
+        self.setCPUTable_slot()
+        # Result_Table 기본 세팅
+        self.Result_Table.setColumnCount(7)
+        self.Result_Table.setHorizontalHeaderLabels(
+            ["개인 공부 투자시간", "팀프 투자 시간", "과목 1 학점", "과목 2 학점", "과목 3 학점", "과목 4 학점", "평균 학점"]
+        )
+        # Result의 Vertical과 StudentList부분은 setCPUTAble_slot으로 넘김
+        
+        header = self.Result_Table.horizontalHeader()
+        for time_table_col in range(7):
+            header.setSectionResizeMode(time_table_col, QHeaderView.Stretch)
+        self.realTimeLabel.setText("Real Time = 0 hour")
+        self.StudentList.setEnabled(True)
+        self.TQ.setEnabled(True)
+        self.TP_Time.setEnabled(True)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. 일단 임시적으로 프로세스 약간 고침, 누구에게 할당되는 프로세스인지 확인 하는 용도로 사용하는 변수만 지정해서 넣었음, 여기엔 show.py에서 할당하는 경우에 int로 들어감. (1,2,3,4)
2. YOSA를 선택했을 때와 그 외의 알고리즘 선택 시 테이블 모양과 버튼 활성/비활성 구현
 - YOSA<->이외 알고리즘 스위칭 될 떄는 reset을 불러 화면을 초기화합니다.
3. YOSA일 떄 프로세스를 add 하는 방법을 구현해 뒀습니다.
 - 학생에게 할당되는 프로세스는 최대 4개이며, 프로세스 4개가 할당되면 그 학생에게 할당 못하게 할당하는 콤보박스에서 그 학생을 지워버립니다. 지우고 나서 cpu_count를 건드리면 문제가 생길 것 같아서 지우고 나서는 cpu_count를 비활성 시키며,  할당 목록에 학생이 전부 사라지면 add 버튼을 비활성 시킵니다.
 - 만약 학생 3이 할당되고 cpu_count를 1이나 2로 바꾸고 run을 돌려버리면 문제가 생길 수도 있다고 생각하여 학생 3을 할당하면 cpu_count에서 1과 2를 날려버리는, 그런 느낌의 기능도 구현해놨습니다.

현재 구현이 되지 않은 것
 - 마지막에 학점들이 나오는 Result_Table을 어떻게 구현할지
 - 레디큐나 간트차트 부분은 아직은 고칠 필요가 없다고 생각해서 구현 자체를 생각은 안해두고 있습니다
  > 이 두 부분은 YOSA가 어떻게 구현되냐에 따라 갈릴 것 같습니다

===================================
2021-04-23 01:07 AM 사항
- 과목 리스트는 Subject(과목명, 학점, BT, 배경색, 해당하는 학생 (0부터 시작)) 식으로 들어가는 식임
- 팀플을 Subjcect로 만들어서 들어가야 한다면, YOSA로 실행 시 Subject(팀플, 팀플 학점, 팀플 BT, 색깔, ???)로 만들어서 넣고 돌리도록 하면 될 것같음
그렇지 않고 YOSA 생성 시 추가로 팀플학점, 팀플 BT 2개의 변수를 받는 식으로 구현을 할 수도 있고
- 현재 간트나 레디큐는 별도로 건드린 것이 없음.
 - Result_Table은 기존에 history처럼 [k][2]에 들어간다는 가정하에 짠 것이고, 별도로 리스트를 만들어서 return 한다면 이에 맞춰서 짜는 건 금방일듯?